### PR TITLE
feat(INFRA-1459): Stale GH actions workflow and README update

### DIFF
--- a/README.md
+++ b/README.md
@@ -17,3 +17,10 @@ If you applied for a fullstack position, complete the assessment tasks for listi
 In the end, we should be able to test the implemented functionality of the backend through the frontend. This means you should start both the backend and frontend locally and use the Warehouse application to ensure everything works seamlessly.
 
 Good luck, and we look forward to seeing your work!
+## Stale PRs
+
+Stale pull requests (PRs) are those that have not had any activity for a certain period of time. It's important to manage stale PRs to keep the project's pull requests manageable and to ensure that contributions are either moving forward or being closed if they are no longer relevant.
+
+Stale PRs are managed by using the [Stale](https://github.com/actions/stale):
+- PRs with no activity for 30 days are marked as stale
+- stale PRs for 10 days are closed


### PR DESCRIPTION
## Jira Task link

Link to [INFRA-1459](https://cloudtalk.atlassian.net/browse/INFRA-1459)

## Why is this change required

Configure [Stale](https://github.com/actions/stale) to firstly mark PRs as stale after 30 days of inactivity and then close them after 10 days of being stale.

## What changed

- Added a new workflow file `stale.yaml` to `.github/workflows` directory.
- updated docs

[INFRA-1459]: https://cloudtalk.atlassian.net/browse/INFRA-1459?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ